### PR TITLE
addition of present()

### DIFF
--- a/proposals/default_optional_arguments/proposal.txt
+++ b/proposals/default_optional_arguments/proposal.txt
@@ -102,7 +102,26 @@ This addition to the language would not break any existing standard
 conforming Fortran program, and thus preserves Fortran's backward
 compatibility.
 
-4. Further discussion
+4. Related intrinsic functions
+
+4.1 present()
+
+When the optional dummy argument has an initializer, the function
+present() will return .true., even if the actual argument is not passed
+by the caller.
+
+Example:
+
+    real function foo(a, b)
+      real, intent(in), optional :: a
+      real, intent(in), optional :: b = 0
+      print*, present(a)  !.true. if an actual argument is provided
+                          !by the caller, .false. otherwise
+      print*, present(b)  !always .true. due to the initializer
+    end function foo
+
+
+5. Further discussion
 
 Online discussion that led to this proposal can be found at
 https://github.com/j3-fortran/fortran_proposals/issue/22.

--- a/proposals/default_optional_arguments/proposal.txt
+++ b/proposals/default_optional_arguments/proposal.txt
@@ -106,9 +106,14 @@ compatibility.
 
 4.1 present()
 
-When the optional dummy argument has an initializer, the function
-present() will return .true., even if the actual argument is not passed
-by the caller.
+There are two possible behaviors of the function present() when an
+initializer is provided.
+
+The first behavior would be that the function present() always returns
+.true. when the optional dummy argument has an initializer, and
+independently of the fact that an actual argument is passed or not
+by the caller. Therefore, with such a behavior, the function present()
+becomes useless for optional arguments with a default value.
 
 Example:
 
@@ -118,6 +123,22 @@ Example:
       print*, present(a)  !.true. if an actual argument is provided
                           !by the caller, .false. otherwise
       print*, present(b)  !always .true. due to the initializer
+    end function foo
+
+The second behavior would be that the function present() returns
+.true. or .false. when an actual argument is passed or not by the
+caller, and independently of the fact that the optional dummy
+argument has, or hasn't an initializer.
+
+A use case of this behavior of the function present() could be:
+
+    real function foo(a, b)
+      real, intent(in) :: a
+      real, intent(in), optional :: b = 1.234
+      if (present(b)) then
+       ... !expensive input validation  here
+      end if
+      ...
     end function foo
 
 


### PR DESCRIPTION
I just added an example on how I think `present` may behave when an initializer is mentioned or not.

I am just wondering what would happen in such a case:

```fortran
module ...
 ....
contains
subroutine foo(i_,value)
 integer, intent(in) :: i_
 integer, optional, intent(out) :: value = 0
 integer :: value_
 !some computations with value_
 if (present(value)) value = value_
end subroutine foo

end module

program test
 use ...
 implicit none
 call foo(10) !what happens with value in foo if present() always return .true.?
end program
```
What will happen with `foo` when it is called without providing an actual argument, since `present()` always returns `.true.` . Probably it should not be a problem since value is already used.